### PR TITLE
Make public static methods not to depend on private props

### DIFF
--- a/src/types/objecttype.ts
+++ b/src/types/objecttype.ts
@@ -43,8 +43,9 @@ export class ObjectType extends GraphQLClassType {
   }
   static get fields(): UnmountedFieldMap {
     var interfaceFields = {};
-    for (let _interfaceIndex in this._interfaces) {
-      let _interface: typeof Interface = this._interfaces[_interfaceIndex];
+    var interfaces = this.interfaces;
+    for (let _interfaceIndex in interfaces) {
+      let _interface: typeof Interface = interfaces[_interfaceIndex];
       interfaceFields = {
         ...interfaceFields,
         ..._interface.fields
@@ -87,7 +88,8 @@ export class ObjectType extends GraphQLClassType {
       fieldName
     ] || this.prototype[fieldName]);
     if (!parentResolver) {
-      for (let _interface of this._interfaces) {
+      var interfaces = this.interfaces;
+      for (let _interface of interfaces) {
         let interfaceResolver = _interface.getResolver(fieldName);
         if (interfaceResolver !== undefined) {
           parentResolver = interfaceResolver;


### PR DESCRIPTION
Found some public static methods of `ObjectType` depends on its private properties.
When extending `ObjectType` to add some fields from database schema,
```ts
// defining extended ObjectType
export class DatabaseObjectType extends ObjectType {
  // ...
  static get fields(): UnmountedFieldMap {
    var interfaceFields = {};
    for (let _interfaceIndex in this._interfaces) { // but this._interfaces is private (error)
      let _interface: typeof Interface = interfaces[_interfaceIndex];
      interfaceFields = {
        ...interfaceFields,
        ..._interface.fields
      };
    }
    var databaseColumnFields = {};
    // ... get fields from database schema

    return {
      ...interfaceFields,
      ...databaseColumnFields,
      ...this._fields
    };
  }
  // ...
}
```

And

`ObjectType.getResolvers` function also uses private `_interfaces`, so it raises exception when I instantiate my `DatabaseObjectType`.

Is this intended behavior?